### PR TITLE
Change minnisblad-adstod to return JSON response

### DIFF
--- a/app/routes/minnisblad_adstod.py
+++ b/app/routes/minnisblad_adstod.py
@@ -1,9 +1,7 @@
 """This module contains the routes for the minnisblad application."""
 
 import os
-from datetime import datetime
 import json
-from tempfile import NamedTemporaryFile
 from fastapi import (
     APIRouter,
     Request,
@@ -14,7 +12,7 @@ from fastapi import (
     Depends,
     status,
 )
-from fastapi.responses import FileResponse, HTMLResponse
+from fastapi.responses import JSONResponse, HTMLResponse
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from fastapi.templating import Jinja2Templates
 from docx import Document
@@ -69,7 +67,7 @@ async def upload_file(
     chapters: str = Form(...),
     _: str = Depends(get_token),
 ):
-    """Process the uploaded file and return the modified document."""
+    """Process the uploaded file and return the JSON response."""
     if (
         file.content_type
         != "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
@@ -94,18 +92,7 @@ async def upload_file(
         selected_chapters = json.loads(chapters)
         respond_format = create_response_format(selected_chapters)
         openai_response = await send_text_to_openai(text, respond_format)
-        # the openai_response is a string, so we need to convert it to a dictionary
-
-        output_file_path = create_docx_from_json(openai_response)
-        # create a timestamp in human readable format
-        timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-        filename = "Frodi_minnisblad_" + timestamp + ".docx"
-
-        return FileResponse(
-            output_file_path,
-            media_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-            filename=filename,
-        )
+        return JSONResponse(content=openai_response)
     except Exception as e:  # pylint: disable=broad-except
         return templates.TemplateResponse(
             "index.html", {"request": request, "error": str(e)}
@@ -191,45 +178,3 @@ def create_response_format(selected_chapters: list) -> dict:
         },
     }
     return base_response
-
-
-def create_docx_from_json(response_json: dict) -> str:
-    """Create a Word document from the JSON response."""
-    # Create a new Word document
-    doc = Document()
-
-    # Add the title
-    doc.add_heading(response_json.get("titill", "Titill Ekki Tiltækur"), level=1)
-
-    # if there is an introduction, add it to the document
-    if "Inngangur" in response_json:
-        doc.add_heading("Inngangur", level=2)
-        doc.add_paragraph(response_json["Inngangur"])
-
-    # if there is markmid, add it to the document
-    if "Markmið" in response_json:
-        doc.add_heading("Markmið", level=2)
-        doc.add_paragraph(response_json["Markmið"])
-
-    if "Áætlun" in response_json:
-        doc.add_heading("Áætlun", level=2)
-        doc.add_paragraph(response_json["Áætlun"])
-
-    # if there are chapters, add them to the document
-    if "kaflar" in response_json:
-        for chapter in response_json["kaflar"]:
-            doc.add_heading(chapter["chapter_title"], level=2)
-            doc.add_paragraph(chapter["content"])
-
-    # if there is a summary, add it to the document
-
-    if "Samantekt" in response_json:
-        doc.add_heading("Samantekt", level=2)
-        doc.add_paragraph(response_json["Samantekt"])
-
-    # Save the document to a temporary file using 'with'
-    with NamedTemporaryFile(delete=False, suffix=".docx") as temp_file:
-        doc.save(temp_file.name)
-        temp_file_path = temp_file.name  # Store the file path to return after closing
-
-    return temp_file_path

--- a/app/routes/minnisblad_adstod.py
+++ b/app/routes/minnisblad_adstod.py
@@ -113,8 +113,9 @@ async def send_text_to_openai(
 ) -> dict:  # pragma: no cover
     """Send the text to the OpenAI API and return the response."""
     # Using the OpenAI client as per your original
-    content_text = """Notendinn sendi þér minnisblað, ef þetta er ekki minnisblað svaraðu allstaðar að þetta er ekki minnisblað
-    en vertu viss um að þetta sé ekki minnisblað. Ef þetta er minnisblað getðu þitt besta til að gefa endurgjöf á því."""
+    content_text = """Notendinn sendi þér minnisblað, farðu mjög varlega yfir það og 
+    finndu dæmi um önnur minnisblöð, 
+    gefðu þér tíma að skoa Íslenskt málfar og stafsetningu."""
     messages = [
         {
             "role": "system",
@@ -147,34 +148,51 @@ async def send_text_to_openai(
 
 def create_response_format(selected_chapters: list) -> dict:
     """Create the response format based on the selected chapters."""
-    base_response = {
+    base_response = base_response = {
         "type": "json_schema",
         "json_schema": {
-            "name": "minnisblad endurgjöf",  # Updated name
-            "strict": True,
-            "schema": {
+            "name": "Minnisblad_adstod",
+            "schema": {  # Correcting to include 'schema' directly
+                "title": "Minnisblad_adstod",
                 "type": "object",
                 "properties": {
-                    "malfar": {
+                    "name": {"type": "string", "description": "The name of the schema"},
+                    "type": {
                         "type": "string",
-                        "description": "Hérna setur þú inn hvað meigi bæta og breyta varðandi málfar, stíl og uppbyggingu minnisblaðsins.",
+                        "enum": [
+                            "object",
+                            "array",
+                            "string",
+                            "number",
+                            "boolean",
+                            "null",
+                        ],
+                        "description": "The type of the schema (should match JSON Schema types)",
                     },
-                    "stafsetning": {
-                        "type": "string",
-                        "description": "Hérna setur þú inn hvað meigi bæta og breyta varðandi stafsetningu",
-                    },
-                    "radleggingar": {
-                        "type": "string",
-                        "description": "Hérna setur þú inn hvað meigi bæta og breyta varðandi almennar raðleggingar",
+                    "properties": {
+                        "type": "object",
+                        "properties": {
+                            "malfar": {
+                                "type": "string",
+                                "description": "Hérna setur þú inn hvað meigi bæta og breyta varðandi málfar, stíl og uppbyggingu minnisblaðsins.",
+                            },
+                            "stafsetning": {
+                                "type": "string",
+                                "description": "Hérna setur þú inn hvað meigi bæta og breyta varðandi stafsetningu passaðu að benda skýrt á allar stafsetningarvillur með að vitna í textan sem á við.",
+                            },
+                            "radleggingar": {
+                                "type": "string",
+                                "description": "Hérna setur þú inn hvað meigi bæta og breyta varðandi almennar raðleggingar. Farðu vel yfir hvernig minnisblöð eru yfir höfuð og hafðu það í huga",
+                            },
+                        },
+                        "required": ["malfar", "stafsetning", "radleggingar"],
+                        "additionalProperties": False,
                     },
                 },
-                "required": [
-                    "malfar",
-                    "stafsetning",
-                    "radleggingar",
-                ],
+                "required": ["name", "type", "properties"],
                 "additionalProperties": False,
             },
         },
     }
+
     return base_response

--- a/app/routes/minnisblad_adstod.py
+++ b/app/routes/minnisblad_adstod.py
@@ -136,7 +136,7 @@ async def send_text_to_openai(
         model="gpt-4o",
         messages=messages,
         temperature=1,
-        max_tokens=2048,
+        max_tokens=4000,
         top_p=1,
         frequency_penalty=0,
         presence_penalty=0,
@@ -148,7 +148,7 @@ async def send_text_to_openai(
 
 def create_response_format(selected_chapters: list) -> dict:
     """Create the response format based on the selected chapters."""
-    base_response = base_response = {
+    base_response = {
         "type": "json_schema",
         "json_schema": {
             "name": "Minnisblad_adstod",

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -47,3 +47,23 @@ button:hover {
     border-radius: 5px;
     margin-top: 10px;
 }
+
+/* Styles for the new input fields and JSON response container */
+#json-response {
+    background-color: #f0f0f0;
+    color: #333;
+    border: 1px solid #ccc;
+    padding: 10px;
+    border-radius: 5px;
+    margin-top: 10px;
+    white-space: pre-wrap;
+}
+
+#json-input-fields input {
+    background-color: #e0f7fa;
+    color: #00695c;
+    border: 1px solid #004d40;
+    padding: 10px;
+    border-radius: 5px;
+    margin-top: 10px;
+}

--- a/app/static/css/styles.css
+++ b/app/static/css/styles.css
@@ -38,7 +38,21 @@ button:hover {
     border-radius: 5px;
     margin-top: 10px;
 }
+.malfar-message {
+    background-color: #f8d7da;
+    color: #721c24;
+    border: 1px solid #f5c6cb;
+    padding: 10px;
+    border-radius: 5px;
+    margin-top: 10px;
+    white-space: pre-wrap; /* Allows text to wrap and respects line breaks */
+    word-wrap: break-word; /* Breaks long words to avoid overflow */
 
+}
+#malfar-text {
+    white-space: pre-wrap; /* Enables text wrapping within the <pre> tag */
+    word-wrap: break-word; /* Allows long words to break and wrap within the container */
+}
 .error-message {
     background-color: #f8d7da;
     color: #721c24;

--- a/app/static/minnisblad-adstod.js
+++ b/app/static/minnisblad-adstod.js
@@ -48,14 +48,26 @@ document
       // Process the JSON response
       const jsonResponse = response.data;
 
+      // Extract and format text content for display
+      const malfarText = jsonResponse.properties.malfar
+        .replace(/\\n/g, "<br>")
+        .replace(/\\"/g, '"');
+      const radleggingarText = jsonResponse.properties.radleggingar
+        .replace(/\\n/g, "<br>")
+        .replace(/\\"/g, '"');
+
       // Populate the input fields with the JSON data
       document.getElementById("malfar").value = jsonResponse.malfar;
       document.getElementById("stafsetning").value = jsonResponse.stafsetning;
       document.getElementById("radleggingar").value = jsonResponse.radleggingar;
 
-      // Display the JSON response in the container
-      document.getElementById("json-text").innerText = JSON.stringify(jsonResponse, null, 2);
-      document.getElementById("json-response").classList.remove("hidden");
+      // Display the formatted JSON response in the containers
+      document.getElementById("malfar-text").innerHTML = malfarText;
+      document.getElementById("malfar-message").classList.remove("hidden");
+      document.getElementById("radleggingar-text").innerHTML = radleggingarText;
+      document
+        .getElementById("radleggingar-message")
+        .classList.remove("hidden");
 
       // Display the success message
       document.getElementById("success-message").classList.remove("hidden");

--- a/app/static/minnisblad-adstod.js
+++ b/app/static/minnisblad-adstod.js
@@ -38,7 +38,6 @@ document
         "/minnisblad-adstod/upload/",
         formData,
         {
-          responseType: "blob", // Important for handling binary data
           headers: {
             "Content-Type": "multipart/form-data",
             Authorization: `Bearer ${tokenInput.value}`,
@@ -46,27 +45,20 @@ document
         }
       );
 
-      // Create a blob from the response data
-      const blob = new Blob([response.data], {
-        type: response.headers["content-type"],
-      });
+      // Process the JSON response
+      const jsonResponse = response.data;
 
-      // Create a link to download the file
-      const downloadUrl = URL.createObjectURL(blob);
-      const link = document.createElement("a");
-      link.href = downloadUrl;
-      // Use the filename from the response headers if available
-      const contentDisposition = response.headers["content-disposition"];
-      let filename = "Frodi_minnisblad.docx";
-      if (contentDisposition) {
-        const fileNameMatch = contentDisposition.match(/filename="(.+)"/);
-        if (fileNameMatch.length === 2) filename = fileNameMatch[1];
-      }
-      link.download = filename;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      URL.revokeObjectURL(downloadUrl);
+      // Populate the input fields with the JSON data
+      document.getElementById("malfar").value = jsonResponse.malfar;
+      document.getElementById("stafsetning").value = jsonResponse.stafsetning;
+      document.getElementById("radleggingar").value = jsonResponse.radleggingar;
+
+      // Display the JSON response in the container
+      document.getElementById("json-text").innerText = JSON.stringify(jsonResponse, null, 2);
+      document.getElementById("json-response").classList.remove("hidden");
+
+      // Display the success message
+      document.getElementById("success-message").classList.remove("hidden");
 
       // Clear the file input and token input
       fileInput.value = "";

--- a/app/templates/minnisblad-adstod.html
+++ b/app/templates/minnisblad-adstod.html
@@ -105,10 +105,73 @@
     <h2 class="text-xl font-bold mb-2">Error:</h2>
     <p id="error-text"></p>
   </div>
+
+  <!-- Success message container -->
+  <div
+    id="success-message"
+    class="mt-4 p-4 bg-green-100 text-green-800 rounded-lg hidden"
+  >
+    <h2 class="text-xl font-bold mb-2">Success:</h2>
+    <p id="success-text"></p>
+  </div>
+
+  <!-- JSON response container -->
+  <div
+    id="json-response"
+    class="mt-4 p-4 bg-gray-100 text-gray-800 rounded-lg hidden"
+  >
+    <h2 class="text-xl font-bold mb-2">JSON Response:</h2>
+    <pre id="json-text"></pre>
+  </div>
+
+  <!-- Input fields for JSON response -->
+  <div id="json-input-fields" class="mt-4 hidden">
+    <div class="mb-4">
+      <label for="malfar" class="block text-sm font-medium text-gray-700 mb-2">
+        Málfar:
+      </label>
+      <input
+        type="text"
+        id="malfar"
+        name="malfar"
+        class="w-full border border-gray-300 p-2 rounded-md"
+        readonly
+      />
+    </div>
+    <div class="mb-4">
+      <label
+        for="stafsetning"
+        class="block text-sm font-medium text-gray-700 mb-2"
+      >
+        Stafsetning:
+      </label>
+      <input
+        type="text"
+        id="stafsetning"
+        name="stafsetning"
+        class="w-full border border-gray-300 p-2 rounded-md"
+        readonly
+      />
+    </div>
+    <div class="mb-4">
+      <label
+        for="radleggingar"
+        class="block text-sm font-medium text-gray-700 mb-2"
+      >
+        Ráðleggingar:
+      </label>
+      <input
+        type="text"
+        id="radleggingar"
+        name="radleggingar"
+        class="w-full border border-gray-300 p-2 rounded-md"
+        readonly
+      />
+    </div>
+  </div>
 </main>
 
 <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
 <script src="/static/minnisblad-adstod.js"></script>
-
 
 {% endblock %}

--- a/app/templates/minnisblad-adstod.html
+++ b/app/templates/minnisblad-adstod.html
@@ -1,18 +1,11 @@
-{% extends "base.html" %}
-
-{% block content %}
+{% extends "base.html" %} {% block content %}
 <main class="container mx-auto px-4 py-8 flex-grow">
   <h1 class="text-3xl font-bold mb-4">Welcome to Office Assistant</h1>
-  <p class="mb-4">
-    This is the main page of the Office Assistant application.
-  </p>
+  <p class="mb-4">This is the main page of the Office Assistant application.</p>
   <form id="upload-form" class="bg-white p-6 rounded-lg shadow-md">
     <!-- Token input field -->
     <div class="mb-4">
-      <label
-        for="token"
-        class="block text-sm font-medium text-gray-700 mb-2"
-      >
+      <label for="token" class="block text-sm font-medium text-gray-700 mb-2">
         Enter your token:
       </label>
       <input
@@ -61,21 +54,11 @@
         <label for="samantekt">Samantekt</label>
       </div>
       <div>
-        <input
-          type="checkbox"
-          id="aaetlun"
-          name="chapters"
-          value="aaetlun"
-        />
+        <input type="checkbox" id="aaetlun" name="chapters" value="aaetlun" />
         <label for="aaetlun">Áætlun</label>
       </div>
       <div>
-        <input
-          type="checkbox"
-          id="markmid"
-          name="chapters"
-          value="markmid"
-        />
+        <input type="checkbox" id="markmid" name="chapters" value="markmid" />
         <label for="markmid">Markmið</label>
       </div>
     </div>
@@ -93,8 +76,8 @@
     id="loading"
     class="mt-4 p-4 bg-blue-100 text-blue-800 rounded-lg hidden"
   >
-    <i class="fas fa-spinner fa-spin mr-2"></i> Processing... This may take
-    up to a minute. Please do not refresh the page.
+    <i class="fas fa-spinner fa-spin mr-2"></i> Processing... This may take up
+    to a minute. Please do not refresh the page.
   </div>
 
   <!-- Error message container -->
@@ -117,11 +100,24 @@
 
   <!-- JSON response container -->
   <div
-    id="json-response"
-    class="mt-4 p-4 bg-gray-100 text-gray-800 rounded-lg hidden"
+    id="malfar-message"
+    class="mt-4 p-4 bg-green-100 text-gray-800 rounded-lg hidden"
   >
-    <h2 class="text-xl font-bold mb-2">JSON Response:</h2>
-    <pre id="json-text"></pre>
+    <h2 class="text-xl font-bold mb-2">
+      Málfar
+    </h2>
+    <pre id="malfar-text"  style="white-space: pre-wrap; word-wrap: break-word;"</pre>
+  </div>
+
+  <!--radleggingar div-->
+  <div
+    id="radleggingar-message"
+    class="mt-4 p-4 bg-green-100 text-gray-800 rounded-lg"
+  >
+    <h2 class="text-xl font-bold mb-2">
+      Ráðleggingar
+    </h2>
+    <pre id="radleggingar-text"  style="white-space: pre-wrap; word-wrap: break-word;"</pre>
   </div>
 
   <!-- Input fields for JSON response -->


### PR DESCRIPTION
Modify the `minnisblad-adstod` endpoint to return JSON response instead of a Word file and update the frontend to display the JSON response.

* **Backend Changes:**
  - Modify `upload_file` function in `app/routes/minnisblad_adstod.py` to return JSON response from OpenAI.
  - Remove code that creates a Word document from the JSON response.
  - Update `send_text_to_openai` function to return JSON response directly.

* **Frontend Changes:**
  - Add input fields and containers in `app/templates/minnisblad-adstod.html` to display JSON response.
  - Update JavaScript in `app/static/minnisblad-adstod.js` to handle JSON response, populate input fields, and display JSON response.
  - Add styles in `app/static/css/styles.css` for new input fields and JSON response container.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/StefnirKristjansson/frodi/pull/17?shareId=325e24df-1388-4c21-bd41-360fd005269b).