### PR TITLE
Bump openai version to 1.55.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ sqlmodel==0.0.22
 Jinja2==3.1.4
 python-docx==1.1.2
 python-multipart==0.0.17
-openai==1.55.0
+openai==1.55.3


### PR DESCRIPTION
Update the openai dependency to the latest version for improved functionality and performance.